### PR TITLE
Add missing torch import with speaker diarization pipeline

### DIFF
--- a/Pyannote_plays_and_Whisper_rhymes_v_2_0.ipynb
+++ b/Pyannote_plays_and_Whisper_rhymes_v_2_0.ipynb
@@ -1119,6 +1119,7 @@
     {
       "cell_type": "code",
       "source": [
+        "import torch\n",
         "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
         "pipeline.to(device)"
       ],


### PR DESCRIPTION
Missing torch import in the cell that checks if cude device is available with speaker diarization. #5 